### PR TITLE
Fix memcached_dump for memcached server 1.4.23+

### DIFF
--- a/libmemcached/version.cc
+++ b/libmemcached/version.cc
@@ -228,3 +228,10 @@ memcached_return_t memcached_version(memcached_st *shell)
 
   return MEMCACHED_INVALID_ARGUMENTS;
 }
+
+int32_t memcached_version_cmp(memcached_instance_st* instance, uint8_t major, uint8_t minor, uint8_t micro)
+{
+  uint32_t cmp_version = (major << 16) | (minor << 8) | micro;
+  uint32_t server_version = (instance->major_version << 16) | (instance->minor_version << 8) | instance->micro_version;
+  return server_version - cmp_version;
+}

--- a/libmemcached/version.hpp
+++ b/libmemcached/version.hpp
@@ -42,3 +42,4 @@
 #pragma once
 
 void memcached_version_instance(memcached_instance_st*);
+int32_t memcached_version_cmp(memcached_instance_st* instance, uint8_t major, uint8_t minor, uint8_t micro);


### PR DESCRIPTION
## Problem

When running the tests on master, I get `FAIL: tests/libmemcached-1.0/testapp` when testing against memcached 1.6.9 with the following logged in test-suite.log for that failure

```
Assertion failed: (response_rc == MEMCACHED_SUCCESS), function ascii_dump, file libmemcached/dump.cc, line 126.
FAIL tests/libmemcached-1.0/testapp (exit status: 134)
```

This is because https://github.com/memcached/memcached/commit/9bce42f27c88a88f94c5e5345ced205a0ab36e89 changed MAX_NUMBER_OF_SLAB_CLASSES to 64 in memcached 1.4.23 so now gets a client error when trying to cachedump for slab id 64.

## Solution

Query the server version and use a version check to avoid querying for a slab id above the maximum for any given memcached instance.